### PR TITLE
fix: change field name containing targets for mail notifications

### DIFF
--- a/src/main/groovy/io/saagie/plugin/dataops/models/Alerting.groovy
+++ b/src/main/groovy/io/saagie/plugin/dataops/models/Alerting.groovy
@@ -1,6 +1,7 @@
 package io.saagie.plugin.dataops.models
 
 class Alerting implements IMapable {
+    @Deprecated
     List<String> emails = []
     List<String> logins = []
     List<String> statusList = []
@@ -8,8 +9,12 @@ class Alerting implements IMapable {
     @Override
     Map toMap() {
         if (emails.empty || logins.empty || statusList.empty) return null
+
+        if (emails) {
+            logins = emails
+        }
+
         return [
-            emails    : emails,
             logins    : logins,
             statusList: statusList
         ]

--- a/src/main/groovy/io/saagie/plugin/dataops/models/Job.groovy
+++ b/src/main/groovy/io/saagie/plugin/dataops/models/Job.groovy
@@ -18,17 +18,31 @@ class Job implements IMapable {
 
     @Override
     Map toMap() {
-        return [
-            name          : name,
-            id            : id,
-            projectId     : projectId,
-            description   : description,
-            category      : category,
-            technology    : [id: technology],
-            cronScheduling: cronScheduling,
-            isScheduled   : isScheduled,
-            isStreaming   : isStreaming,
-            alerting      : alerting.toMap(),
-        ]
+        if (technology) {
+            return [
+                name          : name,
+                id            : id,
+                projectId     : projectId,
+                description   : description,
+                category      : category,
+                technology    : [id: technology],
+                cronScheduling: cronScheduling,
+                isScheduled   : isScheduled,
+                isStreaming   : isStreaming,
+                alerting      : alerting.toMap(),
+            ]
+        } else {
+            return [
+                name          : name,
+                id            : id,
+                projectId     : projectId,
+                description   : description,
+                category      : category,
+                cronScheduling: cronScheduling,
+                isScheduled   : isScheduled,
+                isStreaming   : isStreaming,
+                alerting      : alerting.toMap(),
+            ]
+        }
     }
 }

--- a/src/main/groovy/io/saagie/plugin/dataops/utils/SaagieUtils.groovy
+++ b/src/main/groovy/io/saagie/plugin/dataops/utils/SaagieUtils.groovy
@@ -169,14 +169,14 @@ class SaagieUtils {
             .build()
 
         def gqVariables = jsonGenerator.toJson([
-            job       : job.toMap(),
+            job: job.toMap(),
             jobVersion: jobVersion.toMap()
         ])
 
         // quick hack needed because the toJson seems to update the converted object, even with a clone
         jobVersion.packageInfo.name = file.absolutePath
 
-        // Needed bacause wa can't exlude a field from the excludeNull() rule of the JsonGenerator
+        // Needed because we can't exlude a field from the excludeNull() rule of the JsonGenerator
         def nullFile = '},"file":null}'
         def gqVariablesWithNullFile = "${gqVariables.reverse().drop(2).reverse()}${nullFile}"
 

--- a/src/main/groovy/io/saagie/plugin/dataops/utils/SaagieUtils.groovy
+++ b/src/main/groovy/io/saagie/plugin/dataops/utils/SaagieUtils.groovy
@@ -105,7 +105,7 @@ class SaagieUtils {
                     cronScheduling
                     scheduleStatus
                     alerting {
-                        emails
+                        logins
                         statusList
                     }
                     isStreaming

--- a/src/main/groovy/io/saagie/plugin/dataops/utils/SaagieUtils.groovy
+++ b/src/main/groovy/io/saagie/plugin/dataops/utils/SaagieUtils.groovy
@@ -105,7 +105,11 @@ class SaagieUtils {
                     cronScheduling
                     scheduleStatus
                     alerting {
-                        logins
+                        loginEmails {
+                            login
+                            email
+                        }
+                        emails
                         statusList
                     }
                     isStreaming
@@ -520,7 +524,7 @@ class SaagieUtils {
                 stopPipelineInstance(pipelineInstanceId: $pipelineInstanceId) {
                     id
                     status
-                }  
+                }
             }
         ''', gqVariables)
 


### PR DESCRIPTION
The field structure of the object Job has changed. job/alerting/emails has been replaced by job/alerting/logins approx 2w ago (version?). It makes the plugin failing at creating a job in Saagie. The fix update the field name. Fix issue #63.