### PR TITLE
fix(projectsUpdateJob): set the runtimeVersion param to be required

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,6 +5,7 @@ val validationApiVersion = "2.0.0.Final"
 val hibernateValidatorVersion = "6.0.2.Final"
 val javaxElVersion = "3.0.0"
 val glassfishElVersion = "2.2.6"
+val byteBuddyVersion = "1.10.3"
 
 val nexusUsername: String by project
 val nexusPassword: String by project
@@ -48,6 +49,7 @@ dependencies {
     implementation("org.hibernate.validator:hibernate-validator-annotation-processor:$hibernateValidatorVersion")
     implementation("javax.el:javax.el-api:$javaxElVersion")
     implementation("org.glassfish.web:javax.el:$glassfishElVersion")
+    implementation("net.bytebuddy:byte-buddy:$byteBuddyVersion")
 
     testImplementation(gradleTestKit())
     testImplementation("org.spockframework:spock-core:1.3-groovy-2.4")

--- a/src/main/groovy/io/saagie/plugin/dataops/clients/SaagieClient.groovy
+++ b/src/main/groovy/io/saagie/plugin/dataops/clients/SaagieClient.groovy
@@ -400,7 +400,8 @@ class SaagieClient {
     String updateProjectJobWithGraphQL() {
         logger.info('Starting updateProjectJob task')
         if (configuration?.job?.id == null ||
-            (configuration?.job?.isScheduled && !configuration?.job?.cronScheduling)
+            (configuration?.job?.isScheduled && !configuration?.job?.cronScheduling) ||
+            (configuration?.jobVersion?.exists() && !configuration?.jobVersion?.runtimeVersion)
         ) {
             logger.error(BAD_PROJECT_CONFIG.replaceAll('%WIKI%', taskName))
             throw new InvalidUserDataException(BAD_PROJECT_CONFIG.replaceAll('%WIKI%', taskName))


### PR DESCRIPTION
- set the runtimeVersion param to be required
- set usePreviousPackage automatically based on the content of the jobVersion.packageInfo.name