### PR TITLE
Delete temporary files if task fails.

### DIFF
--- a/src/main/groovy/io/saagie/plugin/dataops/clients/SaagieClient.groovy
+++ b/src/main/groovy/io/saagie/plugin/dataops/clients/SaagieClient.groovy
@@ -1511,7 +1511,9 @@ class SaagieClient {
 				def parsedNewlyCreatedJob = null
 				// change the job to Queue so we can remove the first
 				if (listJobs && nameExist) {
+					jobToImport.id = foundNameId
 					addJobVersion(jobToImport, jobVersionToImport)
+					
 				} else {
 					versions = versions as Queue
 					if (versions && versions.size() >= 1) {
@@ -1588,7 +1590,7 @@ class SaagieClient {
 						name : newMappedPipeline.pipeline.name
 				]
 				
-				if (versions && versions.size() >= 1) {
+				if (versions?.size() >= 1) {
 					versions.each {
 						if (!parsedNewlyCreatedPipeline?.id && !pipelineFoundId) {
 							throw new GradleException("Couldn't get id for the pipeline after creation or update")
@@ -1610,7 +1612,7 @@ class SaagieClient {
 				
 			}
 			
-			if (jobsConfigFromExportedZip && jobsConfigFromExportedZip.jobs) {
+			if (jobsConfigFromExportedZip?.jobs) {
 				ImportJobService.importAndCreateJobs(
 						jobsConfigFromExportedZip.jobs,
 						configuration,
@@ -1618,7 +1620,7 @@ class SaagieClient {
 				)
 			}
 			
-			if (pipelinesConfigFromExportedZip && pipelinesConfigFromExportedZip.pipelines && response.status == 'success') {
+			if ( pipelinesConfigFromExportedZip?.pipelines && response.status == 'success') {
 				def newlistJobs = getJobListByNameAndId()
 				ImportPipelineService.importAndCreatePipelines(
 						pipelinesConfigFromExportedZip.pipelines,

--- a/src/main/groovy/io/saagie/plugin/dataops/clients/SaagieClient.groovy
+++ b/src/main/groovy/io/saagie/plugin/dataops/clients/SaagieClient.groovy
@@ -1627,7 +1627,6 @@ class SaagieClient {
 						newlistJobs
 				)
 			}
-			throw new GradleException("testing invalid import")
 			return response
 		} catch (InvalidUserDataException invalidUserDataException) {
 			throw invalidUserDataException

--- a/src/main/groovy/io/saagie/plugin/dataops/clients/SaagieClient.groovy
+++ b/src/main/groovy/io/saagie/plugin/dataops/clients/SaagieClient.groovy
@@ -1476,159 +1476,170 @@ class SaagieClient {
 		( customDirectoryExist, tempFolder ) = getTemporaryFile(configuration.importArtifacts.temporary_directory, customDirectoryExist)
 		
 		try {
-			ZipUtils.unzip(exportedJobFilePath, tempFolder.absolutePath)
-		} catch (IOException e) {
-			logger.error('An error occurred when unzipping the artifacts export file.', e.message)
-		}
-		
-		def exportedJobZipNameWithoutExt = exportedJob.name.replaceFirst(~/\.[^\.]+$/, '')
-		def exportedArtifactsPathRoot = new File("${tempFolder.absolutePath}/${exportedJobZipNameWithoutExt}")
-		def jobsConfigFromExportedZip = SaagieClientUtils.extractJobConfigAndPackageFromExportedJob(exportedArtifactsPathRoot)
-		def pipelinesConfigFromExportedZip = SaagieClientUtils.extractPipelineConfigAndPackageFromExportedPipeline(exportedArtifactsPathRoot)
-		def response = [
-				status   : 'success',
-				job      : [],
-				pipeline : []
-		]
-		def listJobs = null
-		def callbackJobToDebug = { newMappedJobData, job, id, versions = null ->
-			def jobToImport = new Job()
-			def jobVersionToImport = new JobVersion()
-			jobToImport = newMappedJobData.job
-			jobVersionToImport = newMappedJobData.jobVersion
-			listJobs = getJobListByNameAndId()
-			boolean nameExist = false
-			def foundNameId = null
-			if (listJobs) {
-				listJobs.each {
-					if (it.name == newMappedJobData.job.name) {
-						nameExist = true
-						foundNameId = it.id
-					}
-				}
-			}
-			def parsedNewlyCreatedJob = null
-			// change the job to Queue so we can remove the first
-			if (listJobs && nameExist) {
-				addJobVersion(jobToImport, jobVersionToImport)
-			} else {
-				versions = versions as Queue
-				if (versions && versions.size() >= 1) {
-					def firstVersionInV1Format = versions.poll()
-					JobVersion firstVersion = ImportJobService.convertFromMapToJsonVersion(firstVersionInV1Format)
-					jobVersionToImport = firstVersion
-				}
-				def resultCreatedJob = createProjectJobWithOrWithoutFile(jobToImport, jobVersionToImport)
-				parsedNewlyCreatedJob = slurper.parseText(resultCreatedJob)
+			try {
+				ZipUtils.unzip(exportedJobFilePath, tempFolder.absolutePath)
+			} catch (IOException e) {
+				logger.error('An error occurred when unzipping the artifacts export file.', e.message)
 			}
 			
-			response.job << [
-					id   : job.key,
-					name : newMappedJobData.job.name
+			def exportedJobZipNameWithoutExt = exportedJob.name.replaceFirst(~/\.[^\.]+$/, '')
+			def exportedArtifactsPathRoot = new File("${tempFolder.absolutePath}/${exportedJobZipNameWithoutExt}")
+			def jobsConfigFromExportedZip = SaagieClientUtils.extractJobConfigAndPackageFromExportedJob(exportedArtifactsPathRoot)
+			def pipelinesConfigFromExportedZip = SaagieClientUtils.extractPipelineConfigAndPackageFromExportedPipeline(exportedArtifactsPathRoot)
+			def response = [
+					status   : 'success',
+					job      : [],
+					pipeline : []
 			]
-			
-			if (versions && versions.size() >= 1) {
-				if (!parsedNewlyCreatedJob?.id && !foundNameId) {
-					throw new GradleException("Couldn't get id for the job after creation or update")
-				}
-				if (parsedNewlyCreatedJob?.id) {
-					jobToImport.id = parsedNewlyCreatedJob?.id
-				} else {
-					jobToImport.id = foundNameId
-				}
-				versions.each {
-					JobVersion jobVersionFromVersions = ImportJobService.convertFromMapToJsonVersion(it)
-					addJobVersion(jobToImport, jobVersionFromVersions)
-				}
-				
-				response.job.last()  << [
-						versions: versions.size()
-				]
-			}
-			
-		}
-		
-		def listPipelines = null
-		def callbackPipelinesToDebug = { newMappedPipeline, pipeline, id, versions, newlistJobs ->
-			listPipelines = getPipelineListByNameAndId()
-			def pipelineToImport = newMappedPipeline.pipeline
-			def pipelineVersionToImport = newMappedPipeline.pipelineVersion
-			boolean nameExist = false
-			def pipelineFoundId = null
-			if (listPipelines) {
-				listPipelines.each {
-					if (it.name == newMappedPipeline.pipeline.name) {
-						pipelineFoundId = it.id
-						nameExist = true
+			def listJobs = null
+			def callbackJobToDebug = { newMappedJobData, job, id, versions = null ->
+				def jobToImport = new Job()
+				def jobVersionToImport = new JobVersion()
+				jobToImport = newMappedJobData.job
+				jobVersionToImport = newMappedJobData.jobVersion
+				listJobs = getJobListByNameAndId()
+				boolean nameExist = false
+				def foundNameId = null
+				if (listJobs) {
+					listJobs.each {
+						if (it.name == newMappedJobData.job.name) {
+							nameExist = true
+							foundNameId = it.id
+						}
 					}
 				}
+				def parsedNewlyCreatedJob = null
 				// change the job to Queue so we can remove the first
-			}
-			
-			pipelineToImport.id = pipelineFoundId
-			def parsedNewlyCreatedPipeline = null
-			
-			if (listPipelines && nameExist) {
-				updatePipelineVersion(pipelineToImport, pipelineVersionToImport)
-			} else {
-				if (versions && versions.size() >= 1) {
+				if (listJobs && nameExist) {
+					addJobVersion(jobToImport, jobVersionToImport)
+				} else {
 					versions = versions as Queue
-					def firstVersionInV1Format = versions.poll()
-					PipelineVersion firstVersion = ImportPipelineService.convertFromMapToJsonVersion(firstVersionInV1Format, newlistJobs)
-					pipelineVersionToImport = firstVersion
+					if (versions && versions.size() >= 1) {
+						def firstVersionInV1Format = versions.poll()
+						JobVersion firstVersion = ImportJobService.convertFromMapToJsonVersion(firstVersionInV1Format)
+						jobVersionToImport = firstVersion
+					}
+					def resultCreatedJob = createProjectJobWithOrWithoutFile(jobToImport, jobVersionToImport)
+					parsedNewlyCreatedJob = slurper.parseText(resultCreatedJob)
 				}
 				
-				def newlyCreatedPipeline = createProjectPipeline(pipelineToImport, pipelineVersionToImport)
-				parsedNewlyCreatedPipeline = slurper.parseText(newlyCreatedPipeline)
-			}
-			
-			response.pipeline << [
-					id   : pipeline.key,
-					name : newMappedPipeline.pipeline.name
-			]
-			
-			if (versions && versions.size() >= 1) {
-				versions.each {
-					if (!parsedNewlyCreatedPipeline?.id && !pipelineFoundId) {
-						throw new GradleException("Couldn't get id for the pipeline after creation or update")
-					}
-					if (parsedNewlyCreatedPipeline?.id) {
-						pipelineToImport.id = parsedNewlyCreatedPipeline?.id
-					} else {
-						pipelineToImport.id = pipelineFoundId
-					}
-					PipelineVersion pipelineVersionFromVersions = ImportPipelineService.convertFromMapToJsonVersion(it, newlistJobs)
-					updatePipelineVersion(pipelineToImport, pipelineVersionFromVersions)
-					
-				}
-				
-				response.pipeline.last() << [
-						versions: versions.size()
+				response.job << [
+						id   : job.key,
+						name : newMappedJobData.job.name
 				]
+				
+				if (versions && versions.size() >= 1) {
+					if (!parsedNewlyCreatedJob?.id && !foundNameId) {
+						throw new GradleException("Couldn't get id for the job after creation or update")
+					}
+					if (parsedNewlyCreatedJob?.id) {
+						jobToImport.id = parsedNewlyCreatedJob?.id
+					} else {
+						jobToImport.id = foundNameId
+					}
+					versions.each {
+						JobVersion jobVersionFromVersions = ImportJobService.convertFromMapToJsonVersion(it)
+						addJobVersion(jobToImport, jobVersionFromVersions)
+					}
+					
+					response.job.last() << [
+							versions : versions.size()
+					]
+				}
+				
 			}
 			
+			def listPipelines = null
+			def callbackPipelinesToDebug = { newMappedPipeline, pipeline, id, versions, newlistJobs ->
+				listPipelines = getPipelineListByNameAndId()
+				def pipelineToImport = newMappedPipeline.pipeline
+				def pipelineVersionToImport = newMappedPipeline.pipelineVersion
+				boolean nameExist = false
+				def pipelineFoundId = null
+				if (listPipelines) {
+					listPipelines.each {
+						if (it.name == newMappedPipeline.pipeline.name) {
+							pipelineFoundId = it.id
+							nameExist = true
+						}
+					}
+					// change the job to Queue so we can remove the first
+				}
+				
+				pipelineToImport.id = pipelineFoundId
+				def parsedNewlyCreatedPipeline = null
+				
+				if (listPipelines && nameExist) {
+					updatePipelineVersion(pipelineToImport, pipelineVersionToImport)
+				} else {
+					if (versions && versions.size() >= 1) {
+						versions = versions as Queue
+						def firstVersionInV1Format = versions.poll()
+						PipelineVersion firstVersion = ImportPipelineService.convertFromMapToJsonVersion(firstVersionInV1Format, newlistJobs)
+						pipelineVersionToImport = firstVersion
+					}
+					
+					def newlyCreatedPipeline = createProjectPipeline(pipelineToImport, pipelineVersionToImport)
+					parsedNewlyCreatedPipeline = slurper.parseText(newlyCreatedPipeline)
+				}
+				
+				response.pipeline << [
+						id   : pipeline.key,
+						name : newMappedPipeline.pipeline.name
+				]
+				
+				if (versions && versions.size() >= 1) {
+					versions.each {
+						if (!parsedNewlyCreatedPipeline?.id && !pipelineFoundId) {
+							throw new GradleException("Couldn't get id for the pipeline after creation or update")
+						}
+						if (parsedNewlyCreatedPipeline?.id) {
+							pipelineToImport.id = parsedNewlyCreatedPipeline?.id
+						} else {
+							pipelineToImport.id = pipelineFoundId
+						}
+						PipelineVersion pipelineVersionFromVersions = ImportPipelineService.convertFromMapToJsonVersion(it, newlistJobs)
+						updatePipelineVersion(pipelineToImport, pipelineVersionFromVersions)
+						
+					}
+					
+					response.pipeline.last() << [
+							versions : versions.size()
+					]
+				}
+				
+			}
+			
+			if (jobsConfigFromExportedZip && jobsConfigFromExportedZip.jobs) {
+				ImportJobService.importAndCreateJobs(
+						jobsConfigFromExportedZip.jobs,
+						configuration,
+						callbackJobToDebug
+				)
+			}
+			
+			if (pipelinesConfigFromExportedZip && pipelinesConfigFromExportedZip.pipelines && response.status == 'success') {
+				def newlistJobs = getJobListByNameAndId()
+				ImportPipelineService.importAndCreatePipelines(
+						pipelinesConfigFromExportedZip.pipelines,
+						configuration,
+						callbackPipelinesToDebug,
+						newlistJobs
+				)
+			}
+			throw new GradleException("testing invalid import")
+			return response
+		} catch (InvalidUserDataException invalidUserDataException) {
+			throw invalidUserDataException
+		} catch (GradleException stopActionException) {
+			throw stopActionException
+		} catch (Exception exception) {
+			logger.error(message)
+			logger.error("${exception.message} ${potentialFunctionName ?: ''}")
+			throw exception
+		} finally {
+			SaagieUtils.cleanDirectory(tempFolder, logger)
 		}
-		
-		if (jobsConfigFromExportedZip && jobsConfigFromExportedZip.jobs) {
-			ImportJobService.importAndCreateJobs(
-					jobsConfigFromExportedZip.jobs,
-					configuration,
-					callbackJobToDebug
-			)
-		}
-		
-		if (pipelinesConfigFromExportedZip && pipelinesConfigFromExportedZip.pipelines && response.status == 'success') {
-			def newlistJobs = getJobListByNameAndId()
-			ImportPipelineService.importAndCreatePipelines(
-					pipelinesConfigFromExportedZip.pipelines,
-					configuration,
-					callbackPipelinesToDebug,
-					newlistJobs
-			)
-		}
-		
-		SaagieUtils.cleanDirectory(tempFolder, logger)
-		return response
 	}
 	
 	

--- a/src/main/groovy/io/saagie/plugin/dataops/clients/SaagieClient.groovy
+++ b/src/main/groovy/io/saagie/plugin/dataops/clients/SaagieClient.groovy
@@ -1633,8 +1633,7 @@ class SaagieClient {
 		} catch (GradleException stopActionException) {
 			throw stopActionException
 		} catch (Exception exception) {
-			logger.error(message)
-			logger.error("${exception.message} ${potentialFunctionName ?: ''}")
+			logger.error(exception.message)
 			throw exception
 		} finally {
 			SaagieUtils.cleanDirectory(tempFolder, logger)

--- a/src/main/groovy/io/saagie/plugin/dataops/tasks/projects/artifact/ProjectsImportJobTask.groovy
+++ b/src/main/groovy/io/saagie/plugin/dataops/tasks/projects/artifact/ProjectsImportJobTask.groovy
@@ -19,10 +19,10 @@ class ProjectsImportJobTask extends DefaultTask {
 	
 	@TaskAction
 	def importProjectJob() {
-		saagieClient = new SaagieClient( configuration, taskName )
+		saagieClient = new SaagieClient(configuration, taskName)
 		
 		def result = saagieClient.importJob()
-		logger.quiet( result )
+		logger.quiet(result)
 		return result
 	}
 }

--- a/src/main/groovy/io/saagie/plugin/dataops/utils/directory/ZippingFolder.groovy
+++ b/src/main/groovy/io/saagie/plugin/dataops/utils/directory/ZippingFolder.groovy
@@ -1,5 +1,6 @@
 package io.saagie.plugin.dataops.utils.directory
 
+import io.saagie.plugin.dataops.utils.SaagieUtils
 import net.lingala.zip4j.ZipFile
 import org.gradle.api.GradleException
 import org.gradle.api.logging.Logger
@@ -21,16 +22,10 @@ class ZippingFolder {
 		try {
 			new ZipFile( zipFileName ).addFolder( new File( inputDir ) )
 			logger.debug( "Temporary file cache name : ${ tempFile.name }" )
-			if ( isNotDefaultTemp ) {
-				deleteInsideDirectory( new File( tempFile.getParent() ) )
-			} else {
-				boolean isDeletedTmpFile = tempFile.deleteDir()
-				if ( !isDeletedTmpFile ) {
-					throw new GradleException( "One of the files didn't get deleted. File name: ${ tempFile.name }" )
-				}
-			}
 		} catch ( IOException ex ) {
 			throw new GradleException( ex.message )
+		} finally {
+			SaagieUtils.cleanDirectory(tempFile, logger)
 		}
 	}
 	


### PR DESCRIPTION
## Why ?
We want to remove temporary files if tasks fails

## Links / Ressources
https://github.com/saagie/gradle-saagie-dataops-plugin/issues/260

## Actual status / Investigations

User can choose default tmp folder of the system or custom `tmp` folder by defining `temporary_directory = "URL_OF_TMP_FOLDER"`when using tasks
`projectsImport`
`projectsExport`
`projectsExportV1`
Both `projectsExport` and `projectsExportV1` use same methode `export` to export data to zip file.

Export and Import use different method for files deletion, we need to refactor that code in one.

## How?

We wrap the code of importJob and exception methode, and we need to add `finally` portion of the exception catch so we can use the delete method for temporary files. , we need to keep in mind that another issue have the same fix so there will be conflicts later.

https://github.com/saagie/gradle-saagie-dataops-plugin/pull/263

import task use `cleanDirectory` to delete the temporary files

```
static cleanDirectory( File temp, Logger logger ) {
	try {
		temp.deleteDir()
	} catch (Exception exception) {
		logger.warn('The directory couldn\'t be cleaned')
		logger.warn(exception.message)
	}
}
```

export uses this methode 
```
if ( isNotDefaultTemp ) {
	deleteInsideDirectory( new File( tempFile.getParent() ) )
} else {
	boolean isDeletedTmpFile = tempFile.deleteDir()
	if ( !isDeletedTmpFile ) {
		throw new GradleException( "One of the files didn't get deleted. File name: ${ tempFile.name }" )
	}
}
```

We need to refactor both method in one,  and implement it inside the `SaagieUtils` Class. 
i tested the implementation and i could remove the `isNotDefaultTemp` part, works fine with import delete function

Finally i need to add to export and import method

```
} catch ( IOException ex ) {
	throw new GradleException( ex.message )
} finally {
       SaagieUtils.cleanDirectory(tempFolder, logger)
}

```