### PR TITLE
include jobs automaticaly when exporting pipeline from v1

### DIFF
--- a/src/main/groovy/io/saagie/plugin/dataops/clients/SaagieClient.groovy
+++ b/src/main/groovy/io/saagie/plugin/dataops/clients/SaagieClient.groovy
@@ -867,6 +867,7 @@ class SaagieClient {
 	
 	String exportArtifactsV1() {
 		logger.debug('Starting Export artifacts v1 task')
+		configuration.pipeline.include_job = true
 		checkRequiredConfig(
 				!configuration?.exportArtifacts?.export_file
 		)

--- a/src/test/groovy/io/saagie/plugin/tasks/utils/CronConvertionTests.groovy
+++ b/src/test/groovy/io/saagie/plugin/tasks/utils/CronConvertionTests.groovy
@@ -5,34 +5,34 @@ import spock.lang.Specification
 import spock.lang.Title
 
 @Title("Utils classes tests")
-class CronConvertionTests extends Specification  {
-    def "Cron convertion : Schedule v1 convertion must produce valide cron"() {
-        given:
-            def listDateFromV1 = [
-                "R10/2020-05-12T14:47:15.525Z/PT2H12M",
-                "R0/2019-12-06T08:59:29.336Z/P0Y0M1DT0H0M0S",
-                "R0/2018-01-25T17:17:54.008Z/P0Y0M1DT0H0M0S",
-                "R0/2020-01-29T16:14:44.866Z/P0Y0M1DT0H0M0S",
-                "R/2020-05-12T14:45:55.899Z/P1D",
-                "R/2019-04-05T09:37:46.273Z/P1M"
-            ]
-            def listExpectedValues = [
-                "59 9 */1 * *",
-                "47 */2 * * *",
-                "17 18 */1 * *",
-                "14 17 */1 * *",
-                "45 15 */1 * *",
-                "37 10 5 */1 *"
-            ]
-        def results = []
-        when:
-            results = listDateFromV1.collect {element ->
-                return SaagieUtils.convertScheduleV1ToCron(element)
-            }
-            def commons = results.intersect(listExpectedValues)
-            def difference = results.plus(listExpectedValues)
-            difference.removeAll(commons)
-        then:
-        assert true == true // this test doesn t work on remote server => find a way in the future to fix it
-    }
+class CronConvertionTests extends Specification {
+	def "Cron convertion : Schedule v1 convertion must produce valide cron"() {
+		given:
+		def listDateFromV1 = [
+				"R10/2020-05-12T14:47:15.525Z/PT2H12M",
+				"R0/2019-12-06T08:59:29.336Z/P0Y0M1DT0H0M0S",
+				"R0/2018-01-25T17:17:54.008Z/P0Y0M1DT0H0M0S",
+				"R0/2020-01-29T16:14:44.866Z/P0Y0M1DT0H0M0S",
+				"R/2020-05-12T14:45:55.899Z/P1D",
+				"R/2019-04-05T09:37:46.273Z/P1M"
+		]
+		def listExpectedValues = [
+				"59 9 */1 * *",
+				"47 */2 * * *",
+				"17 18 */1 * *",
+				"14 17 */1 * *",
+				"45 15 */1 * *",
+				"37 10 5 */1 *"
+		]
+		def results = []
+		when:
+		results = listDateFromV1.collect { element ->
+			return SaagieUtils.convertScheduleV1ToCron(element)
+		}
+		def commons = results.intersect(listExpectedValues)
+		def difference = results.plus(listExpectedValues)
+		difference.removeAll(commons)
+		then:
+		assert true == true // this test doesn t work on remote server => find a way in the future to fix it
+	}
 }


### PR DESCRIPTION
## Why ?
We want to make the option `include_jobs` set to true when imported from v1.

## Links / Ressources
https://github.com/saagie/gradle-saagie-dataops-plugin/issues/259

## Actual status / Investigations 

When exporting a pipeline from the v1 you must `include_job` because when importing the pipeline we search for the job name in the jobs property of the pipeline from the job list of the v2. and since we export pipeline from v1, the jobs that contains are from v1. so if we don t export them from v1, the import will not find them.

## How?

We set `include_job`to `true` if we use `projectsExportV1` 
**code simulation**
```
String exportArtifactsV1() {
	logger.debug('Starting Export artifacts v1 task')
	configuration.pipeline.include_job = true
```