### PR TITLE
[ Code design in progress ] init export v1 import v2 environment variables PR

### DIFF
--- a/src/test/groovy/io/saagie/plugin/tasks/artifacts/ArtifactsImportTaskTest.groovy
+++ b/src/test/groovy/io/saagie/plugin/tasks/artifacts/ArtifactsImportTaskTest.groovy
@@ -166,6 +166,7 @@ class ArtifactsImportTaskTest extends DataOpsGradleTaskSpecification {
 		enqueueRequest('{"data":{"pipelines":[{"id":"id-1","name":"Test 2"},{"id":"id-2","name":"Test Long"},{"id":"id-3","name":"test pipeline"},{"id":"id-4","name":"test pipeline id 3"},{"id":"id-5","name":"test pipeline id 5"}]}}')
 		enqueueRequest('{"data":{"createPipeline":{"id":"id-1","name":"test pipeline 23"}}}')
 		
+		
 		buildFile << """
             saagie {
                 server {


### PR DESCRIPTION
## Why ?
Saagie plaftorm have **environment variables** that makes it possible for them the define and share data ( in format of [ key : value ]) inside their platform to be used in configurations for their jobs and pipelines ( anything related to CI/CD basicaly ).
Saagie platform have two versions for their platform V1 and V2.
Both versions have the same concept, deploying **Job** and defining **Pipeline**, but they have different representation of their data ( means that both job v1 and job 2 Entity have different format ).

We would like to export environment variables from v1 platform with the `projectsExportV1`. to then import to the target environment  with `projectsImport` task.

## Links / Ressources

https://github.com/saagie/gradle-saagie-dataops-plugin/issues/286

## Actual  status / Investigations

We checked for the **API** call for export v2 of type REST
This is the only API we need for now: 

**Api** for `getting` all **environment variables** :

**GET** `https://saagie-workspace.prod.saagie.io/manager/api/v1/platform/4/envvars`

We already have **EnvVariable**:
```
class EnvVariable {
	
	String scope
	
	ArrayList<String> name
	
	boolean include_all_var = false
	
}
```

We are intrested in **VariableEnvironmentDTO**  used inside the class `ExportVariables`
**VariableEnvironmentDTO** contains : 
```
        String scope
	String id
	String value
	String description
	boolean isPassword
```
Lucky for us the data from v1 and v2 are similaire 

**Variable object recieved from v1 :**
```
{
"id":1573,
"name":"HDFS_PORT",
"value":"50070",
"isPassword":false,
"description":"",
"platformId":4
}
```
Pretty similaire to `VariableEnvironmentDTO` class

## How?

### For export v1:

We need to export environment variable data in a way that match the expected format for import v2 

- [ ] Add property `platformId` to **VariableEnvironmentDTO**
- `platformId` : String 

- [ ] Add `getV1EnvironmentVariables` to `groovy/io/saagie/plugin/dataops/utils/SaagieUtils.groovy` that will fetch all v1 variables

- [ ] Updating `exportArtifactsV1` to `SaagieClient.groovy`, add the logic to get the list of variables from the query `getV1EnvironmentVariables`

### for the Import:

 - [ ] we may need to add `platformId` property to the method `importAndCreateVariables` in the `groovy/io/saagie/plugin/dataops/tasks/service/importTask/ImportVariableService.groovy` whitch will extract the information for the exported variable.

- [ ] we need to make id definition inside ` VariableMapper` optional, the raison we didn't do it before is because export v2 have always id defined, and we use that to see if the variable that is exported exist on the platform that we intend to import to. but v1 is different from v2 so we can't map the id anymore ( doesn't even have the same format )

```
{status=success, job=[{id=22712, name=jupyter/scipy-notebook}], pipeline=[],env=[name=env1,name=env2}
```
- [ ] Write more unit tests for exportV1 and import.
