### PR TITLE
Fix message error for no variables found

### DIFF
--- a/src/main/groovy/io/saagie/plugin/dataops/utils/directory/FolderGenerator.groovy
+++ b/src/main/groovy/io/saagie/plugin/dataops/utils/directory/FolderGenerator.groovy
@@ -391,8 +391,12 @@ class FolderGenerator {
 		return pipelineVersionDetailJson
 	}
 	
-	void generateFolderFromParams() {
-		if (!exportJobList.length && !exportPipelineList.length && !exportVariableList.length) {
+	void generateFolderFromParams( variablesExportedIsEmpty ) {
+		if (variablesExportedIsEmpty && checkExistenceOfJobsPipelinesAndVariables()) {
+			throw new GradleException("Cannot generate zip file")
+		}
+		
+		if (checkExistenceOfJobsPipelinesAndVariables()) {
 			throw new GradleException("jobs, pipelines and variables to be exported cannot be empty at the same time, and cannot generate zip file")
 		}
 		exportJobList.each { exportJob ->
@@ -407,6 +411,9 @@ class FolderGenerator {
 		}
 	}
 	
+	boolean checkExistenceOfJobsPipelinesAndVariables() {
+		return !exportJobList.length && !exportPipelineList.length && !exportVariableList.length
+	}
 	static extractNameFileFromUrl( String url ) {
 		return url.substring(url.lastIndexOf('/') + 1, url.length())
 	}
@@ -419,8 +426,7 @@ class FolderGenerator {
 	}
 	
 	static extractUrlWithoutFileName( String urlString ) {
-		return urlString.replace(extractNameFileFromUrl(urlString), "") ;
-		
+		return urlString.replace(extractNameFileFromUrl(urlString), "")
 	}
 }
 

--- a/src/test/groovy/io/saagie/plugin/tasks/artifacts/ArtifactsExportV2EnvVarTaskTests.groovy
+++ b/src/test/groovy/io/saagie/plugin/tasks/artifacts/ArtifactsExportV2EnvVarTaskTests.groovy
@@ -100,5 +100,4 @@ class ArtifactsExportV2EnvVarTaskTests extends DataOpsGradleTaskSpecification {
 		assert new File("${tempJobDirectory.getAbsolutePath()}/testvariable1.zip").exists()
 		result.output.contains(computedValue)
 	}
-	
 }


### PR DESCRIPTION
**Issue in question:**
https://github.com/saagie/gradle-saagie-dataops-plugin/issues/301

This PR target to fix logging that will be shown in case we request environment variable of type project and we get empty list in response.

In this case We need to 
**Add warning message that shows:**

`WARNING: No environment variable found on the targeted platform with scope project`

**Change error message from :**

_Previous message  :_
jobs, pipelines and variables to be exported cannot be empty at the same time, and cannot generate zip file

_To fix:_

Cannot generate zip file

In case we export other artifacts like jobs or pipelines with envionmnent variables then we need to only show the warning message with the successful logging message