### PR TITLE
add export all artifacts after rearanging the code

### DIFF
--- a/src/main/groovy/io/saagie/plugin/dataops/clients/SaagieClient.groovy
+++ b/src/main/groovy/io/saagie/plugin/dataops/clients/SaagieClient.groovy
@@ -991,7 +991,6 @@ class SaagieClient {
             zippingFolder.generateZip(tempJobDirectory)
 
             logger.debug("path after: {}, ", exportContainer.exportConfigPath)
-
             return JsonOutput.toJson([
                 status    : "success",
                 exportfile: exportContainer.exportConfigPath
@@ -1963,6 +1962,8 @@ class SaagieClient {
             client.newCall(pipelineListRequest).execute().withCloseable { responsePipelineList ->
                 handleErrors(responsePipelineList)
                 String responseBodyForPipelineList = responsePipelineList.body().string()
+                logger.debug("pipelines with name and id : ")
+                logger.debug(responseBodyForPipelineList)
                 def parsedResultForPipelineList = slurper.parseText(responseBodyForPipelineList)
                 if (parsedResultForPipelineList.data?.pipelines) {
                     listPipelines = parsedResultForPipelineList.data.pipelines
@@ -2074,6 +2075,8 @@ class SaagieClient {
             client.newCall(pipelineListRequest).execute().withCloseable { responsePipelineList ->
                 handleErrors(responsePipelineList)
                 String responseBodyForPipelineList = responsePipelineList.body().string()
+                logger.debug("pipelines with full details : ")
+                logger.debug(responseBodyForPipelineList)
                 def parsedResultForPipelineList = slurper.parseText(responseBodyForPipelineList)
                 if (parsedResultForPipelineList.data?.pipelines) {
                     listPipelines = parsedResultForPipelineList.data.pipelines
@@ -2124,6 +2127,8 @@ class SaagieClient {
             client.newCall(projectJobsRequest).execute().withCloseable { responseJobList ->
                 handleErrors(responseJobList)
                 String responseBodyForJobList = responseJobList.body().string()
+                logger.debug("jobs with full details : ")
+                logger.debug(responseBodyForJobList)
                 def parsedResultForJobList = slurper.parseText(responseBodyForJobList)
                 if (parsedResultForJobList.data?.jobs) {
                     listJobs = parsedResultForJobList.data.jobs

--- a/src/main/groovy/io/saagie/plugin/dataops/clients/SaagieClient.groovy
+++ b/src/main/groovy/io/saagie/plugin/dataops/clients/SaagieClient.groovy
@@ -1762,6 +1762,11 @@ class SaagieClient {
                     addJobVersion(jobToImport, jobVersionToImport)
 
                 } else {
+                    if (versions) {
+                        versions.sort { a, b ->
+                            return a.number?.toInteger() <=> b.number?.toInteger()
+                        }
+                    }
                     versions = versions as Queue
                     if (versions && versions.size() >= 1) {
                         def firstVersionInV1Format = versions.poll()
@@ -1822,6 +1827,9 @@ class SaagieClient {
                     updatePipelineVersion(pipelineToImport, pipelineVersionToImport)
                 } else {
                     if (versions && versions.size() >= 1) {
+                        versions.sort { a, b ->
+                            return a.number?.toInteger() <=> b.number?.toInteger()
+                        }
                         versions = versions as Queue
                         def firstVersionInV1Format = versions.poll()
                         PipelineVersion firstVersion = ImportPipelineService.convertFromMapToJsonVersion(firstVersionInV1Format, newlistJobs)
@@ -2103,7 +2111,7 @@ class SaagieClient {
                     }
                 }
 
-                if (pipeline.versions) {
+                if (pipeline?.versions && pipeline?.versions.size() > 1) {
                     pipeline.versions.each {
                         exportPipeline.addPipelineVersionFromV2ApiResult(it)
                     }
@@ -2160,7 +2168,7 @@ class SaagieClient {
                     }
                 }
 
-                if (jobResult.versions) {
+                if (jobResult?.versions && jobResult?.versions.size() > 1) {
                     jobResult.versions.each {
                         exportJob.addJobVersionFromV2ApiResult(it)
                     }

--- a/src/main/groovy/io/saagie/plugin/dataops/clients/SaagieClient.groovy
+++ b/src/main/groovy/io/saagie/plugin/dataops/clients/SaagieClient.groovy
@@ -18,7 +18,6 @@ import io.saagie.plugin.dataops.models.VariableEnvironmentV2DTO
 import io.saagie.plugin.dataops.tasks.projects.enums.JobV1Category
 import io.saagie.plugin.dataops.tasks.projects.enums.JobV1Type
 import io.saagie.plugin.dataops.tasks.service.TechnologyService
-import io.saagie.plugin.dataops.tasks.service.VariableService
 import io.saagie.plugin.dataops.tasks.service.exportTask.ExportContainer
 import io.saagie.plugin.dataops.tasks.service.importTask.ImportJobService
 import io.saagie.plugin.dataops.tasks.service.importTask.ImportPipelineService
@@ -813,7 +812,7 @@ class SaagieClient {
         logger.info('Starting projectsListAllPipelines task')
         checkRequiredConfig(!configuration?.project?.id)
 
-        Request platformListRequest = saagieUtils.getListAllPipelinesRequest()
+        Request platformListRequest = saagieUtils.getAllProjectPipelinesRequest()
         tryCatchClosure({
             client.newCall(platformListRequest).execute().withCloseable { response ->
                 handleErrors(response)
@@ -932,22 +931,20 @@ class SaagieClient {
         )
 
         ExportPipeline[] exportPipelines = []
-        if (configuration.pipeline.ids) {
-            exportPipelines = getListPipelineAndPipelineVersionsFromConfig()
-        }
 
         ExportJobs[] exportJobs = []
-        if (configuration.job.ids) {
-            exportJobs = getListJobAndJobVersionsFromConfig()
-        }
 
         ExportVariables[] exportVariables = []
         boolean variablesExportedIsEmpty = false
-        if (configuration.env.scope) {
-            (exportVariables, variablesExportedIsEmpty) = getVariableListIfConfigIsDefined(this.&getListVariablesV2FromConfig)
+
+        if (configuration.project.include_all_artifacts) {
+            (exportPipelines, exportJobs, exportVariables, variablesExportedIsEmpty) = exportAllArtifactProject()
+        } else {
+            (exportPipelines, exportJobs, exportVariables, variablesExportedIsEmpty) = exportArtifactFormProjectConfiguration()
         }
 
         return export(exportPipelines, exportJobs, exportVariables, variablesExportedIsEmpty)
+
     }
 
     def getVariableListIfConfigIsDefined(getVariableListingClosure) {
@@ -2002,4 +1999,128 @@ class SaagieClient {
             throw exception
         }
     }
+
+    def exportArtifactFormProjectConfiguration() {
+        ExportPipeline[] exportPipelines = []
+        if (configuration.pipeline.ids) {
+            exportPipelines = getListPipelineAndPipelineVersionsFromConfig()
+        }
+
+        ExportJobs[] exportJobs = []
+        if (configuration.job.ids) {
+            exportJobs = getListJobAndJobVersionsFromConfig()
+        }
+
+        ExportVariables[] exportVariables = []
+        boolean variablesExportedIsEmpty = false
+        if (configuration.env.scope) {
+            (exportVariables, variablesExportedIsEmpty) = getVariableListIfConfigIsDefined(this.&getListVariablesV2FromConfig)
+        }
+
+        return [exportPipelines, exportJobs, exportVariables, variablesExportedIsEmpty]
+    }
+
+    def exportAllArtifactProject() {
+
+        ExportPipeline[] exportPipelines = getAllProjectPipelinesFromProject()
+
+        ExportJobs[] exportJobs = getAllProjectJobsFromProject()
+
+
+        ExportVariables[] exportVariables = []
+        boolean variablesExportedIsEmpty = false
+        //we will export only the environment variable with scope project
+        configuration.env.scope = EnvVarScopeTypeEnum.project.name()
+        configuration.env.include_all_var = true
+        (exportVariables, variablesExportedIsEmpty) = getVariableListIfConfigIsDefined(this.&getListVariablesV2FromConfig)
+
+        return [exportPipelines, exportJobs, exportVariables, variablesExportedIsEmpty]
+
+    }
+
+    ExportPipeline[] getAllProjectPipelinesFromProject() {
+        return mapPipelineListForProjectResultFromApiToExportPipeline(this.&getListOfAllProjectPipelines)
+    }
+
+    private getListOfAllProjectPipelines() {
+        def listPipelines = null
+        tryCatchClosure({
+            Request pipelineListRequest = saagieUtils.getAllProjectPipelinesRequest()
+            // the job do
+            client.newCall(pipelineListRequest).execute().withCloseable { responsePipelineList ->
+                handleErrors(responsePipelineList)
+                String responseBodyForPipelineList = responsePipelineList.body().string()
+                def parsedResultForPipelineList = slurper.parseText(responseBodyForPipelineList)
+                if (parsedResultForPipelineList.data?.pipelines) {
+                    listPipelines = parsedResultForPipelineList.data.pipelines
+                }
+                return listPipelines
+            }
+        }, 'Unknown error in getListOfAllProjectPipelines', 'getAllProjectPipelines Request')
+    }
+
+    private ExportPipeline[] mapPipelineListForProjectResultFromApiToExportPipeline(pipelineList) {
+        ExportPipeline exportPipeline = new ExportPipeline()
+
+        def arrayPipelines = []
+
+        pipelineList.each { pipeline ->
+            exportPipeline.setPipelineFromApiResult(pipeline)
+            if (pipeline.versions && !pipeline.versions.isEmpty()) {
+                pipeline.versions.sort { a, b -> a.creationDate <=> b.creationDate }
+                pipeline.versions.each {
+                    if (it.isCurrent) {
+                        exportPipeline.setPipelineVersionFromApiResult(it)
+                    }
+                }
+            }
+            return arrayPipelines.add(exportPipeline)
+        }
+        return arrayPipelines as ExportPipeline[]
+    }
+
+
+    ExportJobs[] getAllProjectJobsFromProject() {
+        return mapJobListForProjectResultFromApiToExportJobs(this.&getListOfAllProjectJobs)
+    }
+
+    private getListOfAllProjectJobs() {
+        def listJobs = null
+        tryCatchClosure({
+            Request projectJobsRequest = saagieUtils.getAllProjectJobsRequest()
+            // the job do
+            client.newCall(projectJobsRequest).execute().withCloseable { responseJobList ->
+                handleErrors(responseJobList)
+                String responseBodyForJobList = responseJobList.body().string()
+                def parsedResultForJobList = slurper.parseText(responseBodyForJobList)
+                if (parsedResultForJobList.data?.jobs) {
+                    listJobs = parsedResultForJobList.data.pipelines
+                }
+                return listJobs
+            }
+        }, 'Unknown error in getListOfAllProjectJobs', 'getProjectJobs Request')
+
+    }
+
+    private ExportJobs[] mapJobListForProjectResultFromApiToExportJobs(jobList) {
+        ExportJobs exportJobs = new ExportJobs()
+
+        def arrayJobs = []
+
+        jobList.each { jobResult ->
+            exportJobs.setJobFromApiResult(jobResult)
+            if (jobResult.versions && !jobResult.versions.isEmpty()) {
+                jobResult.versions.sort { a, b -> a.creationDate <=> b.creationDate }
+                jobResult.versions.each {
+                    if (it.isCurrent) {
+                        exportJobs.setJobVersionFromApiResult(it)
+                    }
+                }
+            }
+            return arrayJobs.add(exportJobs)
+        }
+        return arrayJobs as ExportJobs[]
+    }
+
+
 }

--- a/src/main/groovy/io/saagie/plugin/dataops/models/ExportJob.groovy
+++ b/src/main/groovy/io/saagie/plugin/dataops/models/ExportJob.groovy
@@ -3,7 +3,7 @@ package io.saagie.plugin.dataops.models
 import groovy.transform.TypeChecked
 
 @TypeChecked
-class ExportJobs implements IExists {
+class ExportJob implements IExists {
     JobDTO jobDTO = new JobDTO()
     JobVersionDTO jobVersionDTO = new JobVersionDTO()
     ArrayList<JobVersionDTO> versions = new ArrayList<JobVersionDTO>()
@@ -35,6 +35,12 @@ class ExportJobs implements IExists {
     void addJobVersionFromV1ApiResult(runTimeVersion, currentVersion) {
         JobVersionDTO jobVersionDTOElement = new JobVersionDTO()
         jobVersionDTOElement.setJobVersionFromV1ApiResult(runTimeVersion, currentVersion)
+        versions.add(jobVersionDTOElement)
+    }
+
+    void addJobVersionFromV2ApiResult(version) {
+        JobVersionDTO jobVersionDTOElement = new JobVersionDTO()
+        jobVersionDTOElement.setJobVersionFromApiResult(version)
         versions.add(jobVersionDTOElement)
     }
 }

--- a/src/main/groovy/io/saagie/plugin/dataops/models/ExportPipeline.groovy
+++ b/src/main/groovy/io/saagie/plugin/dataops/models/ExportPipeline.groovy
@@ -31,8 +31,14 @@ class ExportPipeline implements IExists {
     }
 
     void addPipelineVersionDtoToVersions(jobs, String releaseNote, String number = null) {
-        PipelineVersionDTO pipelineVersionDTO = new PipelineVersionDTO()
-        pipelineVersionDTO.setPipelineVersionFromV1ApiResult(jobs, releaseNote, number)
-        versions.add(0, pipelineVersionDTO)
+        PipelineVersionDTO pipelineVersionDTOFromVersionsV1 = new PipelineVersionDTO()
+        pipelineVersionDTOFromVersionsV1.setPipelineVersionFromV1ApiResult(jobs, releaseNote, number)
+        versions.add(0, pipelineVersionDTOFromVersionsV1)
+    }
+
+    void addPipelineVersionFromV2ApiResult(version) {
+        PipelineVersionDTO pipelineVersionDTOFromVersionsV2 = new PipelineVersionDTO()
+        pipelineVersionDTOFromVersionsV2.setPipelineVersionFromApiResult(version)
+        versions.add(0, pipelineVersionDTOFromVersionsV2)
     }
 }

--- a/src/main/groovy/io/saagie/plugin/dataops/models/JobVersionDTO.groovy
+++ b/src/main/groovy/io/saagie/plugin/dataops/models/JobVersionDTO.groovy
@@ -39,6 +39,10 @@ class JobVersionDTO implements IExists, Comparable {
             number = version.number
         }
 
+        if (version.extraTechnology) {
+            extraTechnology = version.extraTechnology
+        }
+
         if (version.packageInfo?.downloadUrl) {
             packageInfo.name = version.packageInfo?.downloadUrl
         }

--- a/src/main/groovy/io/saagie/plugin/dataops/models/JobVersionDTO.groovy
+++ b/src/main/groovy/io/saagie/plugin/dataops/models/JobVersionDTO.groovy
@@ -39,8 +39,8 @@ class JobVersionDTO implements IExists, Comparable {
             number = version.number
         }
 
-        if (version.packageInfo?.name) {
-            packageInfo.name = version.packageInfo?.name
+        if (version.packageInfo?.downloadUrl) {
+            packageInfo.name = version.packageInfo?.downloadUrl
         }
 
     }

--- a/src/main/groovy/io/saagie/plugin/dataops/models/PipelineVersionDTO.groovy
+++ b/src/main/groovy/io/saagie/plugin/dataops/models/PipelineVersionDTO.groovy
@@ -5,7 +5,7 @@ import org.jetbrains.annotations.NotNull
 
 class PipelineVersionDTO implements IExists, Comparable {
     String releaseNote
-    String number
+    def number
     def jobs = []
 
     @Override
@@ -28,8 +28,8 @@ class PipelineVersionDTO implements IExists, Comparable {
     def initPipelineVersionWithCommunFields(pipelineVersionDetailResult) {
         releaseNote = pipelineVersionDetailResult.releaseNote
         jobs = pipelineVersionDetailResult.jobs.collect { [id: it.id] }
-        if (number) {
-            this.number = number
+        if (pipelineVersionDetailResult.number) {
+            this.number = pipelineVersionDetailResult.number
         }
     }
 

--- a/src/main/groovy/io/saagie/plugin/dataops/models/Project.groovy
+++ b/src/main/groovy/io/saagie/plugin/dataops/models/Project.groovy
@@ -13,6 +13,7 @@ class Project implements IMapable {
 
     List<Closure<TechnologyByCategory>> technologyByCategory = []
     List<Closure<SecurityGroup>> authorizedGroups = []
+    boolean include_all_artifacts = false
 
     @Override
     Map toMap() {

--- a/src/main/groovy/io/saagie/plugin/dataops/tasks/service/importTask/ImportPipelineService.groovy
+++ b/src/main/groovy/io/saagie/plugin/dataops/tasks/service/importTask/ImportPipelineService.groovy
@@ -97,10 +97,8 @@ class ImportPipelineService {
             jobs = getJobsNameFromJobList(jobList, pipelineVersionMap.jobs)
         }
 
-        if (pipelineVersion.releaseNote) {
-            pipelineVersion {
-                releaseNote = pipelineVersion.releaseNote
-            }
+        if (pipelineVersionMap.releaseNote) {
+            pipelineVersion.releaseNote = pipelineVersionMap.releaseNote
         }
 
         return pipelineVersion

--- a/src/main/groovy/io/saagie/plugin/dataops/utils/SaagieUtils.groovy
+++ b/src/main/groovy/io/saagie/plugin/dataops/utils/SaagieUtils.groovy
@@ -108,7 +108,7 @@ class SaagieUtils {
     }
 
 
-    Request getProjectJobsRequest() {
+    Request getAllProjectJobsRequest() {
         getProjectJobsRequestBuild('''
             query jobs($projectId: UUID!) {
                 jobs(projectId: $projectId) {
@@ -118,6 +118,19 @@ class SaagieUtils {
                     countJobInstance
                     versions {
                         number
+                        releaseNote
+                        runtimeVersion
+                        packageInfo {
+                            downloadUrl
+                        }
+                        dockerInfo {
+                            image
+                            dockerCredentialsId
+                        }
+                        commandLine
+                        isCurrent
+                        isMajor
+                        creator
                     }
                     category
                     technology {
@@ -962,9 +975,9 @@ class SaagieUtils {
         return newRequest
     }
 
-    Request getListAllPipelinesRequest() {
+    Request getAllProjectPipelinesRequest() {
         Project project = configuration.project
-        logger.debug('Generating getListAllPipelinesRequest for project [id={}]', project.id)
+        logger.debug('Generating getAllProjectPipelinesRequest for project [id={}]', project.id)
 
         def jsonGenerator = new JsonGenerator.Options()
             .excludeNulls()

--- a/src/main/groovy/io/saagie/plugin/dataops/utils/directory/FolderGenerator.groovy
+++ b/src/main/groovy/io/saagie/plugin/dataops/utils/directory/FolderGenerator.groovy
@@ -1,7 +1,7 @@
 package io.saagie.plugin.dataops.utils.directory
 
 import io.saagie.plugin.dataops.DataOpsExtension
-import io.saagie.plugin.dataops.models.ExportJobs
+import io.saagie.plugin.dataops.models.ExportJob
 import groovy.json.JsonBuilder
 import io.saagie.plugin.dataops.models.ExportPipeline
 import io.saagie.plugin.dataops.models.ExportVariables
@@ -14,7 +14,7 @@ import org.gradle.api.GradleException
 
 class FolderGenerator {
 
-    ExportJobs[] exportJobList = []
+    ExportJob[] exportJobList = []
     ExportPipeline[] exportPipelineList = []
     ExportVariables[] exportVariableList = []
     def inputDire
@@ -42,7 +42,7 @@ class FolderGenerator {
     }
 
 
-    void generateFolderForJob(ExportJobs exportJob) {
+    void generateFolderForJob(ExportJob exportJob) {
         def jobId = exportJob.jobDTO.id
         def urlJobIdFolder = "${inputDire}${sl}${name}${sl}Job${sl}${jobId}"
         def folder = new File(urlJobIdFolder);

--- a/src/main/groovy/io/saagie/plugin/dataops/utils/directory/FolderGenerator.groovy
+++ b/src/main/groovy/io/saagie/plugin/dataops/utils/directory/FolderGenerator.groovy
@@ -205,18 +205,6 @@ class FolderGenerator {
         }
 
         if (
-        jobVersionDTO.packageInfo &&
-            jobVersionDTO.packageInfo.name && jobVersionDTO.number || downloadUrl
-        ) {
-            jobVersionDetailJsonObject << [*: [
-                packageInfo: [
-                    downloadUrl: downloadUrl,
-                    name       : jobVersionDTO.packageInfo.name,
-                ]
-            ]]
-        }
-
-        if (
         jobVersionDTO.extraTechnology &&
             jobVersionDTO.extraTechnology.language
         ) {

--- a/src/test/groovy/io/saagie/plugin/tasks/artifacts/ArtifactsExportTaskTests.groovy
+++ b/src/test/groovy/io/saagie/plugin/tasks/artifacts/ArtifactsExportTaskTests.groovy
@@ -274,4 +274,52 @@ class ArtifactsExportTaskTests extends DataOpsGradleTaskSpecification {
         tempJobDirectory.deleteDir()
         tempJobFile.delete()
     }
+
+    def "projectsExportJob should export job, job version, pipeLines, pipeline versions and environment variables"() {
+        given:
+        File tempJobDirectory = File.createTempDir("project", ".tmp")
+        File tempJobFile = File.createTempFile("package", ".tmp")
+        enqueueRequest("""{"data":{"pipelines":[{"id":"pipeline-1","name":"pipeline-1","description":"pipeline-1","versions":[{"number":1,"creationDate":"2019-11-06T07:49:27.235Z","releaseNote":null,"jobs":[{"id":"job-1"},{"id":"job-3"}],"isCurrent":true,"isMajor":false,"creator":"youen.chene"}],"isScheduled":false,"cronScheduling":null,"scheduleStatus":null,"alerting":null},{"id":"pipeline-2","name":"pipeline-2","description":"pipeline-2","versions":[{"number":1,"creationDate":"2019-11-06T07:49:27.235Z","releaseNote":null,"jobs":[{"id":"job-4"},{"id":"job-5"}],"isCurrent":true,"isMajor":false,"creator":"youen.chene"}],"isScheduled":false,"cronScheduling":null,"scheduleStatus":null,"alerting":null}]}}""")
+        enqueueRequest("""{"data":{"jobs":[{"id":"job-2","name":"Test Job to archive2","description":"Description","countJobInstance":5,"versions":[{"number":2,"creationDate":"2019-11-05T17:14:08.635Z","releaseNote":"Fixed release","runtimeVersion":"3.6","packageInfo":{"downloadUrl":"/projects/api/platform/4/project/project-id/job/job-id/version/1/artifact/renan-file.py"},"dockerInfo":null,"commandLine":"python {file} arg1 arg2","isCurrent":true,"isMajor":false,"creator":"admin.user"},{"number":1,"creationDate":"2019-11-05T17:14:08.635Z","releaseNote":"Fixed release 2","runtimeVersion":"3.6","packageInfo":{"downloadUrl":"/projects/api/platform/4/project/project-id/job/job-id/version/1/artifact/renan-file.py"},"dockerInfo":null,"commandLine":"python {file} arg1 arg2","isCurrent":true,"isMajor":false,"creator":"admin.user"}],"category":"Extraction","technology":{"id":"technology-id","label":"Python","isAvailable":true},"isScheduled":false,"cronScheduling":null,"scheduleStatus":null,"alerting":null,"isStreaming":false,"creationDate":"2019-11-05T17:14:08.635Z","migrationStatus":null,"migrationProjectId":null,"isDeletable":false}, {"id":"job-1","name":"Test Job to archive2","description":"Description","countJobInstance":5,"versions":[{"number":1,"creationDate":"2019-11-05T17:14:08.635Z","releaseNote":"Fixed release","runtimeVersion":"3.6","packageInfo":{"downloadUrl":"/projects/api/platform/4/project/project-id/job/job-id/version/1/artifact/renan-file.py"},"dockerInfo":null,"commandLine":"python {file} arg1 arg2","isCurrent":true,"isMajor":false,"creator":"admin.user"}],"category":"Extraction","technology":{"id":"technology-id","label":"Python","isAvailable":true},"isScheduled":false,"cronScheduling":null,"scheduleStatus":null,"alerting":null,"isStreaming":false,"creationDate":"2019-11-05T17:14:08.635Z","migrationStatus":null,"migrationProjectId":null,"isDeletable":false}]}}""")
+        enqueueRequest("{\"data\":{\"projectEnvironmentVariables\":[{\"id\":\"project-environment-1-id\",\"scope\":\"GLOBAL\",\"name\":\"testUX2\",\"value\":\"lala1\",\"description\":\"lala1\",\"isPassword\":false,\"overriddenValues\":[]},{\"id\":\"project-environment-2-id\",\"scope\":\"GLOBAL\",\"name\":\"sjones\",\"value\":null,\"description\":\"description\",\"isPassword\":true,\"overriddenValues\":[]},{\"id\":\"project-environment-3-id\",\"scope\":\"PROJECT\",\"name\":\"globalvar\",\"value\":\"pro\",\"description\":\"pro\",\"isPassword\":false,\"overriddenValues\":[{\"id\":\"project-environment-4-id\",\"scope\":\"GLOBAL\",\"value\":\"GlobalEnvVAr\",\"description\":\"global variable\",\"isPassword\":false}]},{\"id\":\"project-environment-5-id\",\"scope\":\"GLOBAL\",\"name\":\"bbbb\",\"value\":\"bbbbb\",\"description\":\"\",\"isPassword\":false,\"overriddenValues\":[]},{\"id\":\"project-environment-6-id\",\"scope\":\"GLOBAL\",\"name\":\"WEBHDFS_URL\",\"value\":null,\"description\":\"\",\"isPassword\":true,\"overriddenValues\":[]}]}}")
+        enqueueRequest('{"data":{"jobs":[{"id":"id-1","name":"Job from import asdas"},{"id":"id-2","name":"name job 2"},{"id":"id-3","name":"name job 3"}]}}')
+        enqueueRequestFile(tempJobFile)
+        enqueueRequestFile(tempJobFile)
+        enqueueRequestFile(tempJobFile)
+        enqueueRequestFile(tempJobFile)
+        enqueueRequestFile(tempJobFile)
+        buildFile << """
+            saagie {
+                server {
+                    url = 'http://localhost:9000/'
+                    login = 'user'
+                    password = 'password'
+                    environment = 1
+                    useLegacy = false
+                }
+
+                project {
+                    id = 'project-id'
+                    include_all_artifacts = true
+                }
+
+                exportArtifacts {
+                    export_file = '${tempJobDirectory.getAbsolutePath()}/zipfile.zip'
+                    overwrite = true
+                }
+            }
+        """
+
+        when:
+        BuildResult result = gradle(taskName)
+
+        def computedValue = """{"status":"success","exportfile":"${tempJobDirectory.getAbsolutePath()}/zipfile.zip"}"""
+
+        then:
+        notThrown(Exception)
+        assert new File("${tempJobDirectory.getAbsolutePath()}/zipfile.zip").exists()
+        result.output.contains(computedValue)
+        tempJobDirectory.deleteDir()
+        tempJobFile.delete()
+    }
 }


### PR DESCRIPTION
## Why ?
Saagie plaftorm have **environment variables** that makes it possible for them the define and share data ( in format of [ key : value ]) inside their platform to be used in configurations for their jobs and pipelines ( anything related to CI/CD basicaly ).
Saagie platform have two versions for their platform V1 and V2.
Both versions have the same concept, deploying **Job** and defining **Pipeline**, but they have different representation of their data ( means that both job v1 and job 2 Entity have different format ).

We would like to export all the artifacts of a project from v2 platform with the `projectsExport`. to then import to the target environment  with `projectsImport` task.

## Links / Ressources

https://github.com/saagie/gradle-saagie-dataops-plugin/issues/244

## Actual  status / Investigations

We have already implented the export/import V2 of jobs,pipelines and environment varaibles

## How?

### For export v2 with `include_all_artifact`:

We need to export all the artifacts  data of a project in  a way that match the expected format for import v2

- [ ] Add property `include_all_artifact` to **Project** of type **Boolean**.This  property is **optional** and that it's **value by default is false**

- [ ] Update the method `exportArtifactsV2` : it will use one of these following methods depending on the value of `include_all_artifact`

-  if **`include_all_artifact`** is set to **`true`**  ==> **`exportAllArtifactsFromProject`**
-  if **`include_all_artifact`** is set to **`false`**  ==> **`exportArtifactFormProjectConfiguration`** 

- [ ] Add method `exportAllArtifactsFromProject` to **SaagieClient.groovy** : it will return three variables that we will used to generate the zip file.exportJobs of type ExportJob[] , exportPipelines of type ExportPipeline[] and exportVariables of type ExportVariable[] , it will use in case of `include_all_artifact` is set to `true`.it will use the following methods of  **SaagieClient.groovy** 
- `getAllProjectJobsFromProject` 

- `getAllProjectPipelinesFromProject` 

- `getVariableListIfConfigIsDefined`

- [ ] Add the method  `getAllProjectJobsFromProject`  : it will use `getAllProjectJobsRequest` (it's `getProjectJobsRequest` of **SaagieUtils** 
but i will rename it to `getAllProjectJobsRequest` ) and retrun the list of jobs for project

- [ ] Add the method  `getAllProjectPipelinesFromProject`  : it will use `getAllProjectPipelinesRequest`(it's `getListAllPipelinesRequest` of **SaagieUtils** but i will rename it to `getAllProjectPipelinesRequest`) and return a list of pipelines for a project

- [ ] Add the method `getVariableListIfConfigIsDefined` : already exist in **SaagieClient.groovy** , it returns a list of enviroment variables of a project


- [ ] Add method `exportArtifactFormProjectConfiguration` to **SaagieClient.groovy**  : It will have the old functionnality ( main method used to export artifacts from v2 ).After exporting the requested artifacts of the projects it will use in case of `include_all_artifact` is set to `false` , it will return three variables that we will used to generate the zip file.
exportJobs of type ExportJob[] , exportPipelines of type ExportPipeline[] and exportVariables of type ExportVariable[]

### for the Import:

- [ ] Write more unit tests for exportV2 and import  with `include_all_artifact`.