### PR TITLE
Fix issue 324

### DIFF
--- a/src/main/groovy/io/saagie/plugin/dataops/utils/HttpClientBuilder.groovy
+++ b/src/main/groovy/io/saagie/plugin/dataops/utils/HttpClientBuilder.groovy
@@ -85,7 +85,7 @@ class HttpClientBuilder {
         setTimeOutForBuildFromTheConfiguration(builder, configuration).build()
     }
 
-    static setTimeOutForBuildFromTheConfiguration(OkHttpClient.Builder builder, DataOpsExtension configuration) {
+    static OkHttpClient.Builder setTimeOutForBuildFromTheConfiguration(OkHttpClient.Builder builder, DataOpsExtension configuration) {
         builder.connectTimeout(configuration.server.timeout, TimeUnit.SECONDS)
         builder.readTimeout(configuration.server.timeout, TimeUnit.SECONDS)
         builder.writeTimeout(configuration.server.timeout, TimeUnit.SECONDS)


### PR DESCRIPTION
Add use of the timeout property in the configuration file of the project when exporting from the v1 platform
```
saagie {
     server {
        url = saagieurl
        login = saagieuserid
        password = saagiepassword
        environment = saagieplatformid
        jwt = true
        timeout = 20000
}
```


https://github.com/saagie/gradle-saagie-dataops-plugin/issues/324