### PR TITLE
Fix bug when exporting job from v1 to v2

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -48,6 +48,7 @@ dependencies {
     compile("org.apache.httpcomponents", "httpclient", httpclient)
     compile("org.threeten", "threeten-extra", "1.5.0")
     compile("net.lingala.zip4j", "zip4j", "2.6.1")
+    compile("com.squareup.okio", "okio", "2.8.0")
     implementation("javax.validation:validation-api:$validationApiVersion")
     implementation("org.hibernate.validator:hibernate-validator:$hibernateValidatorVersion")
     implementation("org.hibernate.validator:hibernate-validator-annotation-processor:$hibernateValidatorVersion")

--- a/src/main/groovy/io/saagie/plugin/dataops/utils/directory/FolderGenerator.groovy
+++ b/src/main/groovy/io/saagie/plugin/dataops/utils/directory/FolderGenerator.groovy
@@ -103,7 +103,7 @@ class FolderGenerator {
                                 jobId,
                                 it.packageInfo?.name,
                                 it.number as String,
-                                it.isV1
+                                exportJob.isV1
                             )
                         }
                     }

--- a/src/main/groovy/io/saagie/plugin/dataops/utils/directory/FolderGenerator.groovy
+++ b/src/main/groovy/io/saagie/plugin/dataops/utils/directory/FolderGenerator.groovy
@@ -102,7 +102,8 @@ class FolderGenerator {
                                 it.number,
                                 jobId,
                                 it.packageInfo?.name,
-                                it.number as String
+                                it.number as String,
+                                it.isV1
                             )
                         }
                     }
@@ -113,7 +114,9 @@ class FolderGenerator {
                         urlJobIdFolder,
                         exportJob.downloadUrlVersion,
                         jobId,
-                        exportJob.downloadUrl
+                        exportJob.downloadUrl,
+                        "",
+                        exportJob.isV1
                     )
                 }
 


### PR DESCRIPTION
This issue have for objective to fix bug when downloading artifacts from v1 and importing downloaded job to v2, job fail to run because of corrupted files

https://github.com/saagie/gradle-saagie-dataops-plugin/issues/175