### PR TITLE
Fix order of exported jobs for pipeline

### DIFF
--- a/src/main/groovy/io/saagie/plugin/dataops/utils/directory/FolderGenerator.groovy
+++ b/src/main/groovy/io/saagie/plugin/dataops/utils/directory/FolderGenerator.groovy
@@ -349,8 +349,8 @@ class FolderGenerator {
     Map generatePipelineVersion(PipelineVersionDTO pipelineVersionDTO) {
         def jobForPipeVersionArray = []
         if (pipelineVersionDTO && pipelineVersionDTO.jobs) {
-            jobList.each { job ->
-                pipelineVersionDTO?.jobs?.each { jobId ->
+            pipelineVersionDTO?.jobs?.each { jobId ->
+                jobList.each { job ->
                     if (jobId && job && jobId.id == job.id) {
                         jobForPipeVersionArray.add([
                             id  : job.id,


### PR DESCRIPTION

https://github.com/saagie/gradle-saagie-dataops-plugin/issues/351

Fixing orders of exported jobs id for pipelines